### PR TITLE
feat: add admin authentication

### DIFF
--- a/services/admin-panel-service/package.json
+++ b/services/admin-panel-service/package.json
@@ -17,7 +17,8 @@
     "reflect-metadata": "^0.1.13",
     "rxjs": "^7.2.0",
     "typeorm": "^0.2.41",
-    "pg": "^8.7.1"
+    "pg": "^8.7.1",
+    "jsonwebtoken": "^9.0.0"
   },
   "devDependencies": {
     "@nestjs/cli": "^8.0.0",

--- a/services/admin-panel-service/src/admin/admin.controller.ts
+++ b/services/admin-panel-service/src/admin/admin.controller.ts
@@ -1,12 +1,14 @@
-import { Controller, Get, Post, Body } from '@nestjs/common';
+import { Controller, Get, Post, Body, UseGuards } from '@nestjs/common';
 import { AdminService } from './admin.service';
 import { AdminLog, AdminActionType } from './admin.entity';
+import { AdminGuard } from '../auth/admin.guard';
 
 class LogDto {
   action: AdminActionType;
   payload: any;
 }
 
+@UseGuards(AdminGuard)
 @Controller('admin/logs')
 export class AdminController {
   constructor(private svc: AdminService) {}

--- a/services/admin-panel-service/src/admin/admin.module.ts
+++ b/services/admin-panel-service/src/admin/admin.module.ts
@@ -3,9 +3,10 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { AdminService } from './admin.service';
 import { AdminController } from './admin.controller';
 import { AdminLog } from './admin.entity';
+import { AuthModule } from '../auth/auth.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([AdminLog])],
+  imports: [TypeOrmModule.forFeature([AdminLog]), AuthModule],
   providers: [AdminService],
   controllers: [AdminController],
 })

--- a/services/admin-panel-service/src/app.module.ts
+++ b/services/admin-panel-service/src/app.module.ts
@@ -2,8 +2,9 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import ormconfig from '../ormconfig';
 import { AdminModule } from './admin/admin.module';
+import { AuthModule } from './auth/auth.module';
 
 @Module({
-  imports: [TypeOrmModule.forRoot(ormconfig), AdminModule],
+  imports: [TypeOrmModule.forRoot(ormconfig), AuthModule, AdminModule],
 })
 export class AppModule {}

--- a/services/admin-panel-service/src/auth/admin.guard.ts
+++ b/services/admin-panel-service/src/auth/admin.guard.ts
@@ -1,0 +1,19 @@
+import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
+import { AuthService } from './auth.service';
+
+@Injectable()
+export class AdminGuard implements CanActivate {
+  constructor(private auth: AuthService) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const req = context.switchToHttp().getRequest();
+    const authHeader = req.headers['authorization'] || '';
+    const token = authHeader.split(' ')[1];
+    const payload = token ? this.auth.validateToken(token) : null;
+    if (payload && payload.role === 'admin') {
+      req.user = payload;
+      return true;
+    }
+    return false;
+  }
+}

--- a/services/admin-panel-service/src/auth/auth.controller.ts
+++ b/services/admin-panel-service/src/auth/auth.controller.ts
@@ -1,0 +1,11 @@
+import { Controller, Get, Req, UseGuards } from '@nestjs/common';
+import { AdminGuard } from './admin.guard';
+
+@Controller('auth')
+export class AuthController {
+  @UseGuards(AdminGuard)
+  @Get('verify')
+  verify(@Req() req) {
+    return { user: req.user || true };
+  }
+}

--- a/services/admin-panel-service/src/auth/auth.module.ts
+++ b/services/admin-panel-service/src/auth/auth.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { AuthService } from './auth.service';
+import { AuthController } from './auth.controller';
+import { AdminGuard } from './admin.guard';
+
+@Module({
+  providers: [AuthService, AdminGuard],
+  controllers: [AuthController],
+  exports: [AdminGuard],
+})
+export class AuthModule {}

--- a/services/admin-panel-service/src/auth/auth.service.ts
+++ b/services/admin-panel-service/src/auth/auth.service.ts
@@ -1,0 +1,13 @@
+import { Injectable } from '@nestjs/common';
+import * as jwt from 'jsonwebtoken';
+
+@Injectable()
+export class AuthService {
+  validateToken(token: string) {
+    try {
+      return jwt.verify(token, process.env.JWT_SECRET || 'secret');
+    } catch {
+      return null;
+    }
+  }
+}

--- a/web/components/Layout.tsx
+++ b/web/components/Layout.tsx
@@ -1,8 +1,32 @@
 import { Box, Flex } from '@chakra-ui/react';
+import { useRouter } from 'next/router';
+import { useEffect } from 'react';
 import Header from './Header';
 import Sidebar from './Sidebar';
 
+function parseToken(token: string | undefined) {
+  try {
+    if (!token) return null;
+    const payload = token.split('.')[1];
+    return JSON.parse(atob(payload));
+  } catch {
+    return null;
+  }
+}
+
 export default function Layout({ children }: { children: React.ReactNode }) {
+  const router = useRouter();
+  useEffect(() => {
+    const cookie = document.cookie
+      .split('; ')
+      .find((row) => row.startsWith('token='));
+    const token = cookie ? cookie.split('=')[1] : undefined;
+    const payload = parseToken(token);
+    if (!payload || payload.role !== 'admin') {
+      router.replace('/admin/login');
+    }
+  }, [router]);
+
   return (
     <Flex height="100vh">
       <Sidebar />

--- a/web/pages/admin/index.tsx
+++ b/web/pages/admin/index.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { Box, Heading, SimpleGrid, Spinner, Text } from '@chakra-ui/react';
+import { GetServerSideProps } from 'next';
 import Layout from '../../components/Layout';
 
 type Log = { id: string; action: string; payload: any };
@@ -30,3 +31,25 @@ export default function AdminDashboard() {
     </Layout>
   );
 }
+
+export const getServerSideProps: GetServerSideProps = async (ctx) => {
+  const cookie = ctx.req.headers.cookie;
+  const token = cookie
+    ?.split(';')
+    .map((c) => c.trim())
+    .find((c) => c.startsWith('token='))
+    ?.split('=')[1];
+  try {
+    const payload = token
+      ? JSON.parse(Buffer.from(token.split('.')[1], 'base64').toString())
+      : null;
+    if (!payload || payload.role !== 'admin') {
+      throw new Error('unauthorized');
+    }
+    return { props: {} };
+  } catch {
+    return {
+      redirect: { destination: '/admin/login', permanent: false },
+    };
+  }
+};

--- a/web/pages/admin/login.tsx
+++ b/web/pages/admin/login.tsx
@@ -1,0 +1,47 @@
+import { useState } from 'react';
+import { useRouter } from 'next/router';
+import { Box, Button, Heading, Input, VStack } from '@chakra-ui/react';
+
+export default function AdminLogin() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const router = useRouter();
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/auth/login`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, password, role: 'admin' }),
+    });
+    if (res.ok) {
+      const data = await res.json();
+      document.cookie = `token=${data.access_token}; path=/`;
+      router.push('/admin');
+    }
+  }
+
+  return (
+    <Box maxW="sm" mx="auto" mt="20" p="4" borderWidth="1px" borderRadius="md">
+      <Heading mb="4">Admin Login</Heading>
+      <form onSubmit={handleSubmit}>
+        <VStack spacing="4">
+          <Input
+            placeholder="Email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+          />
+          <Input
+            placeholder="Password"
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+          />
+          <Button type="submit" colorScheme="blue" w="full">
+            Login
+          </Button>
+        </VStack>
+      </form>
+    </Box>
+  );
+}


### PR DESCRIPTION
## Summary
- add admin login page and client/server auth checks
- secure admin panel service with JWT-based guard

## Testing
- `npm test` *(fails: jest: not found)*
- `npm run build` in admin-panel-service *(fails: nest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b2aa38c42083338dec768c57bc8a30